### PR TITLE
Use python:3.9 Docker image instead of the FastAPI one.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9
+FROM python:3.9
+
+WORKDIR /app
 
 COPY ./requirements.txt /app/requirements.txt
 
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
 
 COPY ./app /app/app
+
+CMD ["uvicorn", "app.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "80"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+# API
+fastapi
+pydantic
+uvicorn
+
 # Model
 joblib  #==1.0.1
 scikit-learn  #==1.0.2


### PR DESCRIPTION
Use python:3.9 Docker image instead of the FastAPI one.